### PR TITLE
typo "Deutsch"

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,7 @@ languages are currently supported:
 
 * English
 * Français (French)
-* Deutsche (German)
+* Deutsch (German)
 * español (Spanish)
 * português (Portuguese)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ following languages are currently supported:
 
   - English
   - Français (French)
-  - Deutsche (German)
+  - Deutsch (German)
   - español (Spanish)
   - português (Portuguese)
 


### PR DESCRIPTION
"Deutsch" as in German language. "Deutsche" means either Germans, or german as an adjective as in "die deutsche Sprache", the German language. 

Is it correct that español and português are lower case?