### PR TITLE
refactor test_app_1

### DIFF
--- a/tests/testthat/test_app_1.R
+++ b/tests/testthat/test_app_1.R
@@ -3,8 +3,11 @@
 test_that("fix_date_app() works", {
   # Don't run these tests on the CRAN build servers
   skip_on_cran()
-  skip_on_os(c("windows", "linux", "solaris"))
   withr::local_package("shinytest")
 
-  expect_pass(testApp(test_path("apps/fix_date_theme/"), compareImages = TRUE))
+  if (Sys.info()["sysname"] == "Darwin") {
+    expect_pass(testApp(test_path("apps/fix_date_theme/"),
+      compareImages = TRUE
+    ))
+  }
 })

--- a/tests/testthat/test_app_1.R
+++ b/tests/testthat/test_app_1.R
@@ -3,11 +3,8 @@
 test_that("fix_date_app() works", {
   # Don't run these tests on the CRAN build servers
   skip_on_cran()
+  skip_if_not(Sys.info()["sysname"] == "Darwin", message = "Not run on macOS")
   withr::local_package("shinytest")
 
-  if (Sys.info()["sysname"] == "Darwin") {
-    expect_pass(testApp(test_path("apps/fix_date_theme/"),
-      compareImages = TRUE
-    ))
-  }
+  expect_pass(testApp(test_path("apps/fix_date_theme/"), compareImages = TRUE))
 })

--- a/tests/testthat/test_app_1.R
+++ b/tests/testthat/test_app_1.R
@@ -3,11 +3,8 @@
 test_that("fix_date_app() works", {
   # Don't run these tests on the CRAN build servers
   skip_on_cran()
+  skip_on_os(c("windows", "linux", "solaris"))
   withr::local_package("shinytest")
 
-  if (Sys.info()["sysname"] == "Darwin") {
-    expect_pass(testApp(test_path("apps/fix_date_theme/"),
-      compareImages = TRUE
-    ))
-  }
+  expect_pass(testApp(test_path("apps/fix_date_theme/"), compareImages = TRUE))
 })

--- a/tests/testthat/test_app_1.R
+++ b/tests/testthat/test_app_1.R
@@ -1,10 +1,9 @@
 # This file is for testing the applications in the apps/ directory.
 
-library(shinytest)
-
 test_that("fix_date_app() works", {
   # Don't run these tests on the CRAN build servers
   skip_on_cran()
+  withr::local_package("shinytest")
 
   if (Sys.info()["sysname"] == "Darwin") {
     expect_pass(testApp(test_path("apps/fix_date_theme/"),


### PR DESCRIPTION
Another test refactor, this time test_app_1.R

1. load shinytest only locally within the test, to avoid side-effects, cf. [R Packages](https://r-pkgs.org/testing-design.html#self-contained-tests)
2. simplify code (arguably) to run test only on macOS