### PR TITLE
tweak German test-dates

### DIFF
--- a/tests/testthat/test_languages.R
+++ b/tests/testthat/test_languages.R
@@ -5,10 +5,11 @@ test_that("All January translations work", {
       "le 1er janvier 1975"   = "1975-01-01",
       "janv 2020"             = "2020-01-01",
       "januar 2015"           = "2015-01-01",
-      "05 j\u00E4nner 2021"   = "2021-01-05",
-      "j\u00E4n 2003"         = "2003-01-01",
+      "1. Januar 2035"        = "2035-01-01",
+      "05. J\u00E4nner 2021"  = "2021-01-05",
+      "J\u00E4n 2003"         = "2003-01-01",
       "enero 2005"            = "2005-01-01",
-      "jan 2010"              = "2010-01-01",
+      "Jan 2010"              = "2010-01-01",
       "10 de janeiro de 2019" = "2019-01-10"
     )
 
@@ -31,9 +32,9 @@ test_that("All Feburary translations work", {
       "fevrier 2020"            = "2020-02-01",
       "f\u00E9vr 2015"          = "2015-02-01",
       "05 fevr 2021"            = "2021-02-05",
-      "februar 2003"            = "2003-02-01",
+      "29. Februar 2024"        = "2024-02-29",
+      "Feb 2010"                = "2010-02-01",
       "febrero 2005"            = "2005-02-01",
-      "feb 2010"                = "2010-02-01",
       "25 de fevereiro de 2018" = "2018-02-25"
     )
 
@@ -51,14 +52,15 @@ test_that("All Feburary translations work", {
 test_that("All March translations work", {
   dates <-
     c(
-      "1 march 2000"    = "2000-03-01",
-      "15 mars 1975"    = "1975-03-15",
-      "m\u00E4rz 2020"  = "2020-03-01",
-      "marzo 2015"      = "2015-03-01",
-      "marz 2021"       = "2021-03-01",
-      "mar 2003"        = "2003-03-01",
-      "mar\u00E7o 1980" = "1980-03-01",
-      "marco 2000"      = "2000-03-01"
+      "1 march 2000"        = "2000-03-01",
+      "15 mars 1975"        = "1975-03-15",
+      "M\u00E4rz 2020"      = "2020-03-01",
+      "14. M\u00E4rz 1879"  = "1879-03-14",
+      "marzo 2015"          = "2015-03-01",
+      "marz 2021"           = "2021-03-01",
+      "mar 2003"            = "2003-03-01",
+      "mar\u00E7o 1980"     = "1980-03-01",
+      "marco 2000"          = "2000-03-01"
     )
 
   fixed <- fix_date_char(names(dates))
@@ -75,7 +77,7 @@ test_that("All March translations work", {
 test_that("All April translations work", {
   dates <-
     c(
-      "1 April 2000"     = "2000-04-01",
+      "1. April 2000"    = "2000-04-01",
       "Le 15 avril 1975" = "1975-04-15",
       "abril 2020"       = "2020-04-01",
       "abr 2015"         = "2015-04-01",
@@ -98,6 +100,7 @@ test_that("All May translations work", {
     c(
       "1 Mayo 2000"        = "2000-05-01",
       "15 May 1975"        = "1975-05-15",
+      "23. Mai 2020"       = "2020-05-23",
       "Mai 2020"           = "2020-05-01",
       "15 de maio de 1993" = "1993-05-15"
     )
@@ -119,6 +122,7 @@ test_that("All June translations work", {
       "1 June 2000"         = "2000-06-01",
       "15 juin 1975"        = "1975-06-15",
       "junio 2020"          = "2020-06-01",
+      "12. Juni 2050"       = "2050-06-12",
       "Juni 2015"           = "2015-06-01",
       "jun 2021"            = "2021-06-01",
       "12 de junho de 2015" = "2015-06-12"
@@ -142,7 +146,7 @@ test_that("All July translations work", {
       "15 juillet 1975" = "1975-07-15",
       "Juil 2020"       = "2020-07-01",
       "Julio 2015"      = "2015-07-01",
-      "juli 2021"       = "2021-07-01",
+      "Juli 2021"       = "2021-07-01",
       "jul 2003"        = "2003-07-01",
       "julho de 1997"   = "1997-07-01"
     )
@@ -207,7 +211,7 @@ test_that("All October translations work", {
     c(
       "1 october 2000"        = "2000-10-01",
       "15 Octobre 1975"       = "1975-10-15",
-      "oktober 2020"          = "2020-10-01",
+      "Oktober 2020"          = "2020-10-01",
       "Okt 2015"              = "2015-10-01",
       "octubre 2021"          = "2021-10-01",
       "Oct 2003"              = "2003-10-01",
@@ -231,6 +235,7 @@ test_that("All November translations work", {
       "1 november 2000"       = "2000-11-01",
       "15 Novembre 1975"      = "1975-11-15",
       "noviembre 2020"        = "2020-11-01",
+      "9. Nov. 1989"          = "1989-11-09",
       "Nov 2015"              = "2015-11-01",
       "5 de novembro de 1990" = "1990-11-05"
     )
@@ -253,7 +258,7 @@ test_that("All December translations work", {
       "15 d\u00E9cembre 1975"  = "1975-12-15",
       "decembre 2020"          = "2020-12-01",
       "d\u00E9c 2015"          = "2015-12-01",
-      "05 dezember 2021"       = "2021-12-05",
+      "24. Dezember 2021"      = "2021-12-24",
       "Dez 2003"               = "2003-12-01",
       "diciembre 2005"         = "2005-12-01",
       "dic 2010"               = "2010-12-01",


### PR DESCRIPTION
I tweaked some German (and Austrian) test-dates, mostly with a dot (German ordinal number) and capitalised month name. 